### PR TITLE
fix `wsl-open -w`

### DIFF
--- a/wsl-open.sh
+++ b/wsl-open.sh
@@ -164,10 +164,10 @@ while getopts "ha:d:wx" Opt; do
           echo "
           # Adding $Exe as a browser for Bash for Windows
           if [[ \$(uname -r) == *Microsoft ]]; then
-            if [[ -z $BROWSER ]]; then
+            if [[ -z \$BROWSER ]]; then
               export BROWSER=$Exe
             else
-              export BROWSER=$BROWSER:$Exe
+              export BROWSER=\$BROWSER:$Exe
             fi
           fi
           " >>"$BashFile"


### PR DESCRIPTION
`wsl-open -w` currently adds broken code to .bashrc - I see this when I open a terminal:
````
-bash: /home/alister/.bashrc: line 121: unexpected argument `]]' to conditional unary operator
-bash: /home/alister/.bashrc: line 121: syntax error near `;'
-bash: /home/alister/.bashrc: line 121: `            if [[ -z ]]; then'
````
This fixes it.