### PR TITLE
Properly escape $BROWSER variables when writing to .bashrc

### DIFF
--- a/wsl-open.sh
+++ b/wsl-open.sh
@@ -164,10 +164,10 @@ while getopts "ha:d:wx" Opt; do
           echo "
           # Adding $Exe as a browser for Bash for Windows
           if [[ \$(uname -r) == *Microsoft ]]; then
-            if [[ -z $BROWSER ]]; then
+            if [[ -z \$BROWSER ]]; then
               export BROWSER=$Exe
             else
-              export BROWSER=$BROWSER:$Exe
+              export BROWSER=\$BROWSER:$Exe
             fi
           fi
           " >>"$BashFile"


### PR DESCRIPTION
when calling wsl-open -w, the $BROWSER variables are not escaped correctly when they are written to .bashrc