### PR TITLE
Fix small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ repo or via `curl`) and then adding it to your path. Here is an example:
 mkdir ~/bin
 
 # Add the bin folder to your PATH in your bashrc
-echo '[[ -e ~/bin ]] && PATH=$PATH:~/bin' » .bashrc
+echo '[[ -e ~/bin ]] && PATH=$PATH:~/bin' >> .bashrc
 
 # Download the script to a file named 'wsl-open'
 curl -o ~/bin/wsl-open https://raw.githubusercontent.com/4U6U57/wsl-open/master/wsl-open.sh


### PR DESCRIPTION
A `»` won't work in the shell to append to a file.
`>>` has to be used.