### PR TITLE
Support opening file:// links

### DIFF
--- a/wsl-open.sh
+++ b/wsl-open.sh
@@ -187,7 +187,7 @@ done
 shift $(( OPTIND - 1 ))
 
 # Open file
-File=$1
+File=${1#file://}
 if [[ -n $File ]]; then
   if [[ -e $File ]]; then
     # File or directory


### PR DESCRIPTION
Before this change, attempting to open a `file://` link would result in `Start : This command cannot be run due to the error: The system cannot find the file specified.`

There may be a more robust way to handle it, but this was good enough for my use case :)

Opening a pull-request in case you're interested in applying this change or something similar.